### PR TITLE
fix: use pointer instead of reference of unique_ptr

### DIFF
--- a/windows/drag_and_drop_windows_plugin.cpp
+++ b/windows/drag_and_drop_windows_plugin.cpp
@@ -40,8 +40,8 @@ class DragAndDropWindowsPlugin : public flutter::Plugin {
 void DragAndDropWindowsPlugin::RegisterWithRegistrar(
     flutter::PluginRegistrarWindows *registrar) {
   auto plugin = std::make_unique<DragAndDropWindowsPlugin>(registrar->messenger());
-  flutter::WindowProcDelegate delegate([&plugin](HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
-    return plugin->MessageHandler(hwnd, message, wparam, lparam);
+  flutter::WindowProcDelegate delegate([plugin_pointer = plugin.get()](HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
+    return plugin_pointer->MessageHandler(hwnd, message, wparam, lparam);
   });
 
   registrar->RegisterTopLevelWindowProcDelegate(delegate);


### PR DESCRIPTION
The lifetime of unique_ptr itself (not DragAndDropWindowsPlugin's that unique_ptr has) is restricted to the parent scope.
When the delegate lambda is called, plugin references the freed unique_ptr and it causes crash.

This PR will replace that reference by unique_ptr::get, and use pointer to call MessageHandler.