### PR TITLE
Fixed flutter delay when closing program

### DIFF
--- a/windows/drag_and_drop_windows_plugin.cpp
+++ b/windows/drag_and_drop_windows_plugin.cpp
@@ -28,8 +28,6 @@ class DragAndDropWindowsPlugin : public flutter::Plugin {
 
   DragAndDropWindowsPlugin(flutter::BinaryMessenger* messenger);
 
-  virtual ~DragAndDropWindowsPlugin();
-
   private:
     std::optional<LRESULT> MessageHandler(HWND window, UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept;
     std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> event_sink_;
@@ -68,10 +66,6 @@ DragAndDropWindowsPlugin::DragAndDropWindowsPlugin(flutter::BinaryMessenger* mes
       }
   );
   event_channel_->SetStreamHandler(std::move(handler));
-}
-
-DragAndDropWindowsPlugin::~DragAndDropWindowsPlugin() {
-  event_channel_->SetStreamHandler(nullptr);
 }
 
 std::optional<LRESULT> DragAndDropWindowsPlugin::MessageHandler(HWND window, UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept {


### PR DESCRIPTION
When using this plugin, the app hangs for ~10 seconds between the app closing (and the window disappearing) and the actual process exiting. Removing the code in the destructor fixes it and does seem to be required based on how the `connectivity_plus` plugin does things.